### PR TITLE
Expose VM errors without breaking estimateGas

### DIFF
--- a/src/blockchain.rs
+++ b/src/blockchain.rs
@@ -512,15 +512,11 @@ impl Blockchain {
         id: BlockId,
     ) -> impl Future<Item = U256, Error = CallError> {
         self.simulate_transaction(transaction, id)
-            .inspect(|executed| {
-                if let Executed {
-                    exception: Some(e), ..
-                } = executed
-                {
-                    if *e != VmError::Reverted && *e != VmError::OutOfGas {
-                        eprintln!("vm error: {:?}", e);
-                    }
+            .inspect(|executed| match &executed.exception {
+                Some(VmError::Reverted) | Some(VmError::OutOfGas) => {
+                    eprintln!("vm error: {:?}", executed.exception.as_ref().unwrap());
                 }
+                _ => {}
             })
             .map(|executed| executed.gas_used + executed.refunded)
     }


### PR DESCRIPTION
In an unfortunate turn of events, #55 contained a file from the late [errors](https://github.com/oasislabs/oasis-chain/pull/41) branch. The modification breaks gas estimation since it upgrades a `Reverted` error to a full-blown `ExecutionError`, which causes gas estimation to fail and the client to abort the whole transaction.

This PR preserves the usefully debugging functionality that is currently present and also gas estimation.