### PR TITLE
Add oasis-chain artifact builder

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,31 @@
+name: SDK Build
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  oasis-chain:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Build oasis-chain
+        run: cargo build --release
+
+      - name: Get target triple
+        id: get-target-triple
+        run: |
+          triple=$(rustc -Z unstable-options --print target-spec-json | jq -r '."llvm-target"')
+          echo "::set-output name=triple::$triple"
+
+      - name: Upload oasis-chain artifact
+        uses: actions/upload-artifact@v1
+        with:
+          name: oasis-chain-${{ steps.get-target-triple.outputs.triple }}
+          path: target/release/oasis-chain


### PR DESCRIPTION
Until toolstate builds are back, the best we can do is publish github artifacts.
